### PR TITLE
Update to 1.19.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>it.hoxija</groupId>
     <artifactId>TelegramLogin</artifactId>
-    <version>1.1</version>
+    <version>1.2</version>
 
     <properties>
         <maven.compiler.source>11</maven.compiler.source>
@@ -43,7 +43,7 @@
         <dependency>
             <groupId>net.md-5</groupId>
             <artifactId>bungeecord-api</artifactId>
-            <version>1.16-R0.5-SNAPSHOT</version>
+            <version>1.19-R0.1-SNAPSHOT</version>
             <type>jar</type>
             <scope>provided</scope>
         </dependency>
@@ -58,7 +58,7 @@
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
-            <version>1.16.5-R0.1-SNAPSHOT</version>
+            <version>1.19.4-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
 
@@ -81,6 +81,12 @@
             <artifactId>telegrambots</artifactId>
             <version>6.0.1</version>
             <scope>compile</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.12.0</version>
         </dependency>
 
         <dependency>

--- a/src/main/java/it/ivirus/telegramlogin/TelegramLogin.java
+++ b/src/main/java/it/ivirus/telegramlogin/TelegramLogin.java
@@ -34,6 +34,7 @@ public class TelegramLogin extends JavaPlugin {
     private FileConfiguration langConfig;
     private boolean bungeeEnabled = false;
     private boolean loginSessionEnabled = false;
+    private int maxAccountsCount = 0;
     private final Executor executor = runnable -> Bukkit.getScheduler().runTaskAsynchronously(this, runnable);
 
     @Override
@@ -53,6 +54,8 @@ public class TelegramLogin extends JavaPlugin {
         }
         if (this.getConfig().getBoolean("login-session"))
             this.loginSessionEnabled = true;
+
+        maxAccountsCount = this.getConfig().getInt("max-accounts-count");
 
         this.startBot();
         new Task(this).startClearCacheTask();

--- a/src/main/java/it/ivirus/telegramlogin/database/SqlManager.java
+++ b/src/main/java/it/ivirus/telegramlogin/database/SqlManager.java
@@ -68,6 +68,24 @@ public abstract class SqlManager {
         }, plugin.getExecutor());
     }
 
+    public CompletableFuture<Integer> getTelegramPlayersCount(String chatId) {
+        return CompletableFuture.supplyAsync(() -> {
+            try (Connection connection = getConnection();
+                 PreparedStatement statement = connection.prepareStatement("SELECT COUNT(*) as accounts_count FROM " + TABLE_PLAYERS + " WHERE chatID=?")) {
+                statement.setString(1, chatId);
+                ResultSet resultSet = statement.executeQuery();
+                if (resultSet.next()) {
+                    return resultSet.getInt("accounts_count");
+                } else {
+                    return 0;
+                }
+            } catch (SQLException | ClassNotFoundException ex) {
+                ex.printStackTrace();
+            }
+            return 0;
+        }, plugin.getExecutor());
+    }
+
     public CompletableFuture<TelegramPlayer> getTelegramPlayer(String chatId, int accountId) {
         return CompletableFuture.supplyAsync(() -> {
             try (Connection connection = getConnection();

--- a/src/main/java/it/ivirus/telegramlogin/spigot/command/telegramsubcommand/ChangeChatIdSubcmd.java
+++ b/src/main/java/it/ivirus/telegramlogin/spigot/command/telegramsubcommand/ChangeChatIdSubcmd.java
@@ -2,7 +2,7 @@ package it.ivirus.telegramlogin.spigot.command.telegramsubcommand;
 
 import it.ivirus.telegramlogin.spigot.command.SubCommand;
 import it.ivirus.telegramlogin.util.LangConstants;
-import org.apache.commons.lang.math.NumberUtils;
+import org.apache.commons.lang3.math.NumberUtils;
 import org.bukkit.Bukkit;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;

--- a/src/main/java/it/ivirus/telegramlogin/telegram/callbackmanager/textcommand/ConfirmTextCommand.java
+++ b/src/main/java/it/ivirus/telegramlogin/telegram/callbackmanager/textcommand/ConfirmTextCommand.java
@@ -3,7 +3,7 @@ package it.ivirus.telegramlogin.telegram.callbackmanager.textcommand;
 import it.ivirus.telegramlogin.telegram.TelegramBot;
 import it.ivirus.telegramlogin.telegram.callbackmanager.AbstractUpdate;
 import it.ivirus.telegramlogin.util.*;
-import org.apache.commons.lang.math.NumberUtils;
+import org.apache.commons.lang3.math.NumberUtils;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.telegram.telegrambots.meta.api.methods.updatingmessages.DeleteMessage;

--- a/src/main/java/it/ivirus/telegramlogin/telegram/callbackmanager/textcommand/LockTextCommand.java
+++ b/src/main/java/it/ivirus/telegramlogin/telegram/callbackmanager/textcommand/LockTextCommand.java
@@ -6,7 +6,7 @@ import it.ivirus.telegramlogin.util.LangConstants;
 import it.ivirus.telegramlogin.util.MessageFactory;
 import it.ivirus.telegramlogin.util.PluginMessageAction;
 import it.ivirus.telegramlogin.util.Util;
-import org.apache.commons.lang.math.NumberUtils;
+import org.apache.commons.lang3.math.NumberUtils;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.telegram.telegrambots.meta.api.objects.Update;

--- a/src/main/java/it/ivirus/telegramlogin/telegram/callbackmanager/textcommand/UnlockTextCommand.java
+++ b/src/main/java/it/ivirus/telegramlogin/telegram/callbackmanager/textcommand/UnlockTextCommand.java
@@ -6,7 +6,7 @@ import it.ivirus.telegramlogin.util.LangConstants;
 import it.ivirus.telegramlogin.util.MessageFactory;
 import it.ivirus.telegramlogin.util.PluginMessageAction;
 import it.ivirus.telegramlogin.util.Util;
-import org.apache.commons.lang.math.NumberUtils;
+import org.apache.commons.lang3.math.NumberUtils;
 import org.telegram.telegrambots.meta.api.objects.Update;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiException;
 

--- a/src/main/java/it/ivirus/telegramlogin/util/LangConstants.java
+++ b/src/main/java/it/ivirus/telegramlogin/util/LangConstants.java
@@ -2,7 +2,6 @@ package it.ivirus.telegramlogin.util;
 
 import it.ivirus.telegramlogin.TelegramLogin;
 import lombok.Getter;
-import org.bukkit.configuration.file.FileConfiguration;
 
 public enum LangConstants {
 
@@ -38,6 +37,7 @@ public enum LangConstants {
     INGAME_ACCOUNT_LIST_LOCKED("info.in-game.account-list.locked"),
     INGAME_ACCOUNT_LIST_UNLOCKED("info.in-game.account-list.unlocked"),
     INGAME_ACCOUNT_LINKED("info.in-game.account-linked"),
+    INGAME_ACCOUNT_LIMIT_REACHED("errors.in-game.account-limit-reached"),
     INGAME_ADD_CHATID("info.in-game.add-chat-id"),
     INGAME_CHATID_CHANGED("info.in-game.chat-id-changed"),
     INGAME_TARGET_REMOVED("info.in-game.target-removed"),
@@ -48,6 +48,7 @@ public enum LangConstants {
     INGAME_WAIT_FOR_CONFIRM("info.in-game.wait-for-confirm"),
     INGAME_WAIT_FOR_LOGIN_CONFIRM("info.in-game.wait-for-login-confirm"),
     INGAME_INVALID_VALUE("errors.in-game.invalid-value"),
+    INGAME_INVALID_CHAT_ID("errors.in-game.invalid-chat-id"),
     INGAME_OPERATION_ABORTED("info.in-game.operation-aborted"),
     INGAME_ABORT_2FA("info.in-game.2FA.abort-2FA"),
     INGAME_ACCOUNT_DISCONNECTED("info.in-game.2FA.account-disconnected"),

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,4 +1,8 @@
 language: en_US
+
+# Limits max minecraft accounts for one telegram chat id. 0 = unlimited.
+max-accounts-count: 0
+
 #########################################################################
 #                       Database Config                                 #
 #########################################################################

--- a/src/main/resources/languages/en_US.yml
+++ b/src/main/resources/languages/en_US.yml
@@ -1,8 +1,10 @@
 prefix: "&8(&bTelegram&fLogin&8)&r"
 errors:
   in-game:
+    account-limit-reached: "%prefix%&7 &cYou reached the limit of Minecraft accounts"
     no-permission: "%prefix%&7: &cPermission denied."
     invalid-value: "%prefix%&7: &cInvalid value"
+    invalid-chat-id: "%prefix%&7: &cTelegram returned an error. Please check that you have a conversation with the bot"
     only-player: "%prefix%&7: &cCommand executable only by player"
     target-without-telegramLogin:
       - "&cThis player does not exists"

--- a/src/main/resources/languages/ru_RU.yml
+++ b/src/main/resources/languages/ru_RU.yml
@@ -2,8 +2,10 @@
 prefix: "&8(&bTelegram&fLogin&8)&r"
 errors:
   in-game:
+    account-limit-reached: "%prefix%&7 &cВы достигли лимита майнкрафт аккаунтов"
     no-permission: "%prefix%&7: &cВ разрешении отказано."
     invalid-value: "%prefix%&7: &cНедопустимое значение"
+    invalid-chat-id: "%prefix%&7: &cТелеграм вернул ошибку! Проверьте, что у вас есть диалог с ботом"
     only-player: "%prefix%&7: &cКоманда, выполняемая только игроком"
     target-without-telegramLogin:
       - "&cЭтого игрока не существует"


### PR DESCRIPTION
This PR updates the plugin to the newest available Minecraft version (1.19.4).
It also contains small changes like a new setting `max-accounts-count`, which can limit max Minecraft accounts to one telegram account (default: unlimited), and improvement for the user experience when providing incorrect`chat_id`.

TODO:
 - onDisable may produce an error since `Thread.stop()` became unsupported in new Java versions. 
 - it_IT translation for the new messages (hope for some help here).